### PR TITLE
include/bootloader/bootloader_trace.H: send trace to port 0x82

### DIFF
--- a/src/include/bootloader/bootloader_trace.H
+++ b/src/include/bootloader/bootloader_trace.H
@@ -5,7 +5,7 @@
 /*                                                                        */
 /* OpenPOWER HostBoot Project                                             */
 /*                                                                        */
-/* Contributors Listed Below - COPYRIGHT 2015,2017                        */
+/* Contributors Listed Below - COPYRIGHT 2015,2020                        */
 /* [+] International Business Machines Corp.                              */
 /*                                                                        */
 /*                                                                        */
@@ -191,6 +191,9 @@ enum BootloaderTraces
 #ifndef BOOTLOADER_TRACE
 #define BOOTLOADER_TRACE(trace_value) \
 { \
+    asm volatile("stbcix %0, %1, %2; eieio" :: "r"(trace_value), \
+      "b"(IGNORE_HRMOR_MASK + MMIO_GROUP0_CHIP0_LPC_BASE_ADDR + LPCHC_IO_SPACE - LPC_ADDR_START), \
+      "r"(0x82) : "memory"); \
     g_blData->bl_trace[g_blData->bl_trace_index++] = \
         trace_value; \
     g_blData->bl_trace_index %= BOOTLOADER_TRACE_SIZE; \


### PR DESCRIPTION
Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>